### PR TITLE
Add Rythm — non-custodial email paywall using Cashu

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Note: These documentation sites are works in progress (WIP) and welcome feedback
 - [Portal Technologies](https://github.com/PortalTechnologiesInc) is a universal app for identity & payments.
 - [Purrwallet](https://github.com/heathermm55/purrwallet) is a cross-platform Cashu ecash wallet built with Rust and Flutter, featuring a terminal-inspired UI for privacy-focused Bitcoiners.
 - [Receipt.cash](https://github.com/Origami74/receipt-cash) is a bill splitter to snap a picture of a fiat bill and easily split costs auto-converted to Bitcoin. It's based on Cashu payment requests. [Site](https://sugardaddy.cash/)
+- [Rythm](https://rythm.xyz) — non-custodial email paywall where unknown senders attach a Cashu token as a cover charge to prove sincerity. Rythm melts the token on receipt and settles sats to the recipient's Lightning wallet, never storing tokens or funds. Built with cashu-ts, supports V3 and V4 tokens.
 - [Satocash-Applet](https://github.com/Toporin/Satocash-Applet) is an ecash wallet implementation in javacard.
 - [sig4sats](https://github.com/vstabile/sig4sats-script) is a a simple script demonstrating how to atomically exchange Cashu payments for Nostr event signatures using Schnorr adaptor signatures.
 - [Skate Spots](https://nostrhub.io/naddr1qvzqqqrhnypzqg88e9f588nx7wyz4wt0ura23w3yd4hmztqrkr95utwyvgachjepqy2hwumn8ghj7un9d3shjtnyd968gmewwp6kyqqtwd4kzar994ehqmm5wv3d7yj9#skatespots-decentralized-skate-map-community) is skate spot map built on Nostr with an integrated Cashu wallet.


### PR DESCRIPTION
Adds Rythm to the Various nutcases section.

Rythm is a non-custodial email paywall for Gmail and Outlook. Unknown senders attach a Cashu token as a cover charge, which is melted on receipt and settled to the recipient's Lightning wallet. Built with cashu-ts, supports V3 and V4 tokens.

https://rythm.xyz