### PR TITLE
docs: add unmaintained Cashu mint implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,15 +250,27 @@ Note: These documentation sites are works in progress (WIP) and welcome feedback
 - [μNuts](https://github.com/Amperstrand/micronuts) is a Cashu hardware wallet for the STM32F469I-discovery board.
 ## Currently Unmaintained Projects
 
+- [alchemint](https://github.com/kazluu/alchemint) is a Cashu mint written in Elixir.
 - [Cashcrab](https://github.com/thesimplekid/cashcrab) is a Cashu wallet with a flutter UI and with as much logic as possible in rust using [cashu-crab](https://github.com/thesimplekid/cashu-crab) with nostr integration for contacts and messaging.
 - [cashu-client](https://github.com/thunderbiscuit/cashu-client) is a Cashu client library in Kotlin.
 - [cashu-bdhke-kmp](https://github.com/gandlafbtc/cashu-bdhke-kmp) is a Kotlin library that implements the basic cryptographic blinded signature scheme.
 - [cashu-feni](https://github.com/cashubtc/cashu-feni) is a Golang library for Cashu wallets and mints.
+- [cashu-rs-mint](https://github.com/thesimplekid/cashu-rs-mint) is a Cashu mint implementation using CDK (archived).
+- [cashu-ts-mint](https://github.com/gandlafbtc/cashu-ts-mint) is a Cashu mint written in TypeScript.
 - [Cashubrew](https://github.com/AbdelStark/gakimint) is a Cashu mint written in Elixir.
 - [Cashu faucet](https://github.com/gandlafbtc/cashu-faucet) allows you to deposit and withdraw Cashu tokens from a web interface. [Site](https://www.gandlaf.com/faucet/anarchy)
 - [Chamberlain](https://github.com/sovereign-app/chamberlain) is a mint implementation with an Integrated LDK Node using CDK.
 - [Coconut](https://github.com/zig-bitcoin/coconut) is a Cashu mint written in Zig.
 - [Cashu-dart](https://github.com/0xchat-app/cashu-dart) is another Library that allows developers to integrate Cashu easily into apps 
 - [eNuts](https://github.com/cashubtc/eNuts) is a Cashu wallet for Android and IOS. It empowers you with a user-friendly interface that streamlines every step of your ecash journey.
+- [gonuts](https://github.com/elnosh/gonuts) is a Cashu wallet and mint written in Go.
+- [ldk-node-cashu-mint](https://github.com/benthecarman/ldk-node-cashu-mint) is a Cashu mint backed by LDK Node.
+- [lnbits-cashu](https://github.com/cashubtc/lnbits-cashu) is a Cashu mint extension for LNbits based on Nutshell (archived).
+- [lnbits/cashu](https://github.com/lnbits/cashu) is an LNbits Cashu integration (archived).
+- [mint](https://github.com/gandlafbtc/mint) is a Cashu mint project in TypeScript.
 - [Moksha](https://github.com/ngutech21/moksha) is a Cashu wallet and mint written in Rust.
+- [purrmint](https://github.com/heathermm55/purrmint) is a mobile Cashu mint built with Rust and Kotlin.
+- [swift-cashu-mint](https://github.com/SparrowTek/swift-cashu-mint) is a Cashu mint implementation in Swift.
+- [tsnut](https://github.com/adambor/tsnut) is a highly extensible Cashu mint written in TypeScript.
+- [zashu](https://github.com/AbdelStark/zashu) is a Zcash-backed Cashu mint written in Rust.
 


### PR DESCRIPTION
## Summary

Adds **12 unmaintained Cashu mint implementations** to the **Currently Unmaintained Projects** section.

These were found via an extensive GitHub scan against this list, then filtered to:

1. Actual **mint protocol implementations** (or mint+wallet codebases)
2. **Unmaintained** = archived **or** last commit older than ~6 months (cutoff ≈ 2026-01-19)

Companion to #40 (actively maintained mints).

### Added

| Mint | Language | Last activity (approx) | Notes |
|------|----------|------------------------|--------|
| [alchemint](https://github.com/kazluu/alchemint) | Elixir | 2024-11 | Elixir mint |
| [cashu-rs-mint](https://github.com/thesimplekid/cashu-rs-mint) | Rust | 2024-10 | CDK mint (**archived**) |
| [cashu-ts-mint](https://github.com/gandlafbtc/cashu-ts-mint) | TypeScript | 2024-12 | TS mint |
| [gonuts](https://github.com/elnosh/gonuts) | Go | 2025-08 | Go mint + wallet |
| [ldk-node-cashu-mint](https://github.com/benthecarman/ldk-node-cashu-mint) | Rust | 2024-03 | LDK Node-backed mint |
| [lnbits-cashu](https://github.com/cashubtc/lnbits-cashu) | Python | 2024-05 | Nutshell LNbits extension (**archived**) |
| [lnbits/cashu](https://github.com/lnbits/cashu) | Python | 2024-04 | LNbits integration (**archived**) |
| [mint](https://github.com/gandlafbtc/mint) | TypeScript | 2025-01 | TS mint project |
| [purrmint](https://github.com/heathermm55/purrmint) | Kotlin/Rust | 2025-11 | Mobile mint |
| [swift-cashu-mint](https://github.com/SparrowTek/swift-cashu-mint) | Swift | 2025-12 | Swift mint |
| [tsnut](https://github.com/adambor/tsnut) | TypeScript | 2024-07 | Extensible TS mint |
| [zashu](https://github.com/AbdelStark/zashu) | Rust | 2025-12 | Zcash-backed mint |

Existing unmaintained entries are preserved; new mint entries are inserted in approximate alphabetical order.

### Not included here

Actively maintained missing mints (last commit ≤ ~6 months) are in #40.

## Test Plan

- [x] Each link resolves to a public GitHub repo
- [x] Each repo is archived and/or last commit older than ~6 months at scan time
- [x] Descriptions match awesome-list style
- [x] No duplicates of entries already in Currently Unmaintained (Cashubrew, Chamberlain, Coconut, Moksha, etc.)
