### PR TITLE
Update MintRadar URL to mintradar.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Note: These documentation sites are works in progress (WIP) and welcome feedback
 - [Cashumints.space](https://Cashumints.space) is an index of Cashu ecash mints and offers reviews of these mints, complete with comprehensive mint pages.
 - [Mint Audit](https://audit.8333.space/) is a mint auditor and [Mint Watch Bot](https://primal.net/p/npub1cashu0thfukl57lgwtarn7h4jrzrg2e346zc8sjvjd8u5hheds0qlhpt92) is a bot that watches the status of mints.
 - [mint-discovery](https://github.com/jooray/mint-discovery) is a Cashu mint discovery library.
-- [MintRadar](https://mintradar.pedani.eu) — Real-time Cashu mint monitor with uptime, latency, Trust Score, NUT compatibility, watchlist and Nostr reviews. [GitHub](https://github.com/hroomnik007/MintRadar)
+- [MintRadar](https://mintradar.org) — Real-time Cashu mint monitor with uptime, latency, Trust Score, NUT compatibility, watchlist and Nostr reviews. [GitHub](https://github.com/hroomnik007/MintRadar)
 
 ### Restore 
 - [cashu-recover](https://github.com/kaloudis/cashu-recover) is a recovery tool for Cashu wallet proofs and state.


### PR DESCRIPTION
MintRadar's public site moved from https://mintradar.pedani.eu to https://mintradar.org.

This updates the existing Mint Discovery and Audit listing only. Description and GitHub link are unchanged. The old domain 301-redirects to the new one.